### PR TITLE
Default auth_token variable to null

### DIFF
--- a/provision/small/ats-small.tf
+++ b/provision/small/ats-small.tf
@@ -2,6 +2,7 @@
 
 variable "auth_token" {
   type        = string
+  default     = null
   description = "The packet authorization token if not in environment"
 }
 


### PR DESCRIPTION
Default `auth_token` variable to `null` so that the `PACKET_AUTH_TOKEN` environment variable is used if a value is not otherwise provided.