### PR TITLE
Update for CentOS 7.8 and to pin terraform versions

### DIFF
--- a/provision/small/ats-small-userdata.yaml
+++ b/provision/small/ats-small-userdata.yaml
@@ -1,6 +1,5 @@
 #cloud-config
 packages:
-  - ansible
   - selinux-policy-targeted
   - unzip
   - wget
@@ -21,10 +20,11 @@ write_files:
       [ -d ats-postdeploy ] || unzip -qq ats-postdeploy.zip
       [ -d ats-postdeploy ] || mv ats-postdeploy-$${POSTDEPLOY_COMMIT} ats-postdeploy
 
+      yum install -y epel-release
+      yum install -y ansible
+
       ansible-playbook \
         -i inventory.yml ats-deploy/playbook_vpcmido.yml
-
-      yum update -y ansible # need the more recent (EPEL) version for the post-deploy playbook
 
       ansible-playbook \
         --extra-vars ats_demo_state=present \

--- a/provision/small/ats-small.tf
+++ b/provision/small/ats-small.tf
@@ -1,5 +1,14 @@
 # Terraform plan for ats small deployment on packet
 
+terraform {
+  required_version = ">= 0.12.0, < 0.13.0"
+
+  required_providers {
+    packet = "~> 2.7.0"
+    random = "~> 2.2"
+  }
+}
+
 variable "auth_token" {
   type        = string
   default     = null
@@ -70,7 +79,7 @@ locals {
 
 provider "packet" {
   auth_token = local.auth_token
-  version = "~> 2.7"
+  version = "~> 2.7.0"
 }
 
 provider "random" {


### PR DESCRIPTION
We now always use the epel ansible as this is compatible with the post-deployment playbook and the older ansible version in the centos repos is no longer available.

Versions of terraform and the packet provider are now restricted to ones that are compatible with the playbook.

Test: /job/eucalyptus-internal-packet-deploy/26/

Demo was to run a test deployment and verify by checking the `provision.log` on the host.